### PR TITLE
Fix option name typo and make a slew of changes to receiver.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .cache
 .tox/
+build/
+dist/
 *.pyc
 *.egg-info

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Usage
 =====
 
 * Run ``bin/celery zabbix --zabbix-nodename myhost.example.com --zabbix-server zabbix.example.com``.
-  (Alternatively you can pass ``--zabix-agent-config=/etc/zabbix/zabbix_agentd.conf``, then the values for server+nodename will be read from there.)
+  (Alternatively you can pass ``--zabbix-agent-config=/etc/zabbix/zabbix_agentd.conf``, then the values for server+nodename will be read from there.)
 * Import the corresponding `Zabbix Template`_ to set up the matching items.
 
 .. _`Zabbix Template`: https://github.com/ZeitOnline/celery_zabbix/blob/master/zbx_template_celery.xml


### PR DESCRIPTION
Add the ability to take defaults from the config file and override
just one of them from the command line, only open the config file
if any values are required from it.

When using the Server config line from the agent config file take the
first value when it is a comma separated list.

Switch to unicode aware io StringIO.

Stop importing all of celery.bin.base when just Command is needed.

Debug log settings to aid people working out what is in use.

Debug log when zabbix_send is ignored.

gitignore build and dist directories